### PR TITLE
Android security 11.0.0 release 58

### DIFF
--- a/services/surfaceflinger/Scheduler/EventThread.cpp
+++ b/services/surfaceflinger/Scheduler/EventThread.cpp
@@ -139,6 +139,11 @@ void EventThreadConnection::onFirstRef() {
 }
 
 status_t EventThreadConnection::stealReceiveChannel(gui::BitTube* outChannel) {
+    std::scoped_lock lock(mLock);
+    if (mChannel.initCheck() != NO_ERROR) {
+        return NAME_NOT_FOUND;
+    }
+
     outChannel->setReceiveFd(mChannel.moveReceiveFd());
     outChannel->setSendFd(base::unique_fd(dup(mChannel.getSendFd())));
     return NO_ERROR;

--- a/services/surfaceflinger/Scheduler/EventThread.h
+++ b/services/surfaceflinger/Scheduler/EventThread.h
@@ -92,7 +92,8 @@ public:
 private:
     virtual void onFirstRef();
     EventThread* const mEventThread;
-    gui::BitTube mChannel;
+    std::mutex mLock;
+    gui::BitTube mChannel GUARDED_BY(mLock);
 };
 
 class EventThread {


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r58' of https://android.googlesource.com/platform/frameworks/native/ into arrow-11.0

Android security 11.0.0 release 58
Tag: https://android.googlesource.com/platform/frameworks/native/+/refs/tags/android-security-11.0.0_r58

Merge cherrypicks of [18766123] into security-aosp-rvc-release.

Change-Id: [Icbb7109b9bd4e07283bc29ffe546501824524ac2](https://android-review.googlesource.com/#/q/Icbb7109b9bd4e07283bc29ffe546501824524ac2)